### PR TITLE
fix: video player deinit on unmount

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -283,11 +283,12 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         #endif
     }
 
-    deinit {
+    func stop() {
         #if USE_GOOGLE_IMA
-            _imaAdsManager.releaseAds()
+            _imaAdsManager?.releaseAds()
             _imaAdsManager = nil
         #endif
+
         AudioSessionManager.shared.unregisterView(view: self)
 
         NotificationCenter.default.removeObserver(self)
@@ -304,6 +305,10 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
         ReactNativeVideoManager.shared.unregisterView(newInstance: self)
         AudioSessionManager.shared.unregisterView(view: self)
+    }
+
+    deinit {
+        self.stop()
     }
 
     // MARK: - App lifecycle handlers

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -77,6 +77,7 @@ RCT_EXTERN_METHOD(setFullScreenCmd : (nonnull NSNumber*)reactTag fullscreen : (n
 RCT_EXTERN_METHOD(enterPictureInPictureCmd : (nonnull NSNumber*)reactTag)
 RCT_EXTERN_METHOD(exitPictureInPictureCmd : (nonnull NSNumber*)reactTag)
 RCT_EXTERN_METHOD(setSourceCmd : (nonnull NSNumber*)reactTag source : (NSDictionary*)source)
+RCT_EXTERN_METHOD(stop: (nonnull NSNumber*)reactTag)
 
 RCT_EXTERN_METHOD(save
                   : (nonnull NSNumber*)reactTag options

--- a/ios/Video/RCTVideoManager.swift
+++ b/ios/Video/RCTVideoManager.swift
@@ -107,6 +107,14 @@ class RCTVideoManager: RCTViewManager {
         })
     }
 
+    @objc(stop:)
+    func stop(_ reactTag: NSNumber) {
+        performOnVideoView(withReactTag: reactTag, callback: { videoView in
+            videoView?.stop()
+        })
+    }
+
+
     override class func requiresMainQueueSetup() -> Bool {
         return true
     }

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -1,24 +1,23 @@
+import type {ElementRef} from 'react';
 import React, {
-  useState,
+  forwardRef,
   useCallback,
+  useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
-  forwardRef,
-  useImperativeHandle,
+  useState,
 } from 'react';
-import type {ElementRef} from 'react';
-import {View, StyleSheet, Image, Platform, processColor} from 'react-native';
 import type {
-  StyleProp,
+  ImageResizeMode,
   ImageStyle,
   NativeSyntheticEvent,
+  StyleProp,
   ViewStyle,
-  ImageResizeMode,
 } from 'react-native';
+import {Image, Platform, processColor, StyleSheet, View} from 'react-native';
 
-import NativeVideoComponent, {
-  NativeCmcdConfiguration,
-} from './specs/VideoNativeComponent';
+import NativeVideoManager from './specs/NativeVideoManager';
 import type {
   OnAudioFocusChangedData,
   OnAudioTracksData,
@@ -39,21 +38,23 @@ import type {
   OnVideoTracksData,
   VideoSrc,
 } from './specs/VideoNativeComponent';
+import NativeVideoComponent, {
+  NativeCmcdConfiguration,
+} from './specs/VideoNativeComponent';
+import type {
+  CmcdData,
+  OnLoadData,
+  OnReceiveAdEventData,
+  OnTextTracksData,
+  ReactVideoProps,
+  ReactVideoSource,
+} from './types';
+import {CmcdMode, VideoRef, ViewType} from './types';
 import {
   generateHeaderForNative,
   getReactTag,
   resolveAssetSourceForVideo,
 } from './utils';
-import NativeVideoManager from './specs/NativeVideoManager';
-import {ViewType, CmcdMode, VideoRef} from './types';
-import type {
-  OnLoadData,
-  OnTextTracksData,
-  OnReceiveAdEventData,
-  ReactVideoProps,
-  CmcdData,
-  ReactVideoSource,
-} from './types';
 
 const Video = forwardRef<VideoRef, ReactVideoProps>(
   (
@@ -825,6 +826,20 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       }),
       [],
     );
+
+    useEffect(() => {
+      let reactTag: number;
+
+      if (nativeRef.current) {
+        reactTag = getReactTag(nativeRef);
+      }
+
+      return () => {
+        if (reactTag) {
+          NativeVideoManager.stop(reactTag);
+        }
+      };
+    }, []);
 
     return (
       <View style={style}>

--- a/src/specs/NativeVideoManager.ts
+++ b/src/specs/NativeVideoManager.ts
@@ -1,7 +1,7 @@
 import {NativeModules} from 'react-native';
 import type {
-  Int32,
   Float,
+  Int32,
   UnsafeObject,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import type {VideoSaveData} from '../types/video-ref';
@@ -27,6 +27,7 @@ export interface VideoManagerType {
   exitPictureInPictureCmd: (reactTag: number) => Promise<void>;
   save: (reactTag: Int32, option: UnsafeObject) => Promise<VideoSaveData>;
   getCurrentPosition: (reactTag: Int32) => Promise<Int32>;
+  stop: (reactTag: Int32) => Promise<void>;
 }
 
 export default NativeModules.VideoManager as VideoManagerType;


### PR DESCRIPTION
## Summary
Expose a new `stop` external method.

## Motivation
The deinitialization is not performed correctly when the user leaves the player view too quickly.  
As a result, the IMA ads are not released and the audio may still play in the background after the user has left the player view.

## Changes
Added a new `stop` external method, which is also invoked inside the `deinit` block in `RCTVideo`.

## Test Plan
Call the `stop` method when the player view unmounts in React Native.