### PR TITLE
Normalizes language for media option selection

### DIFF
--- a/ios/Video/Features/RCTPlayerOperations.swift
+++ b/ios/Video/Features/RCTPlayerOperations.swift
@@ -104,7 +104,8 @@ enum RCTPlayerOperations {
                 } else {
                     optionValue = currentOption.commonMetadata.map(\.value)[0] as? String
                 }
-                if value == optionValue {
+                
+                if RCTVideoAssetsUtils.normalizeLanguage(value) == RCTVideoAssetsUtils.normalizeLanguage(optionValue) {
                     mediaOption = currentOption
                     break
                 }

--- a/ios/Video/Features/RCTPlayerOperations.swift
+++ b/ios/Video/Features/RCTPlayerOperations.swift
@@ -95,17 +95,19 @@ enum RCTPlayerOperations {
         if type == "disabled" {
             // Do nothing. We want to ensure option is nil
         } else if (type == "language") || (type == "title") {
-            let value = criteria?.value as? String
+            let value = RCTVideoAssetsUtils.getLocale(criteria?.value as? String)
+            
             for i in 0 ..< group.options.count {
                 let currentOption: AVMediaSelectionOption! = group.options[i]
-                var optionValue: String!
+                var optionValue: Locale!
                 if type == "language" {
-                    optionValue = currentOption.extendedLanguageTag
+                    optionValue = currentOption.locale
                 } else {
-                    optionValue = currentOption.commonMetadata.map(\.value)[0] as? String
+                    let lang = currentOption.commonMetadata.map(\.value)[0] as? String
+                    optionValue = RCTVideoAssetsUtils.getLocale(lang)
                 }
                 
-                if RCTVideoAssetsUtils.normalizeLanguage(value) == RCTVideoAssetsUtils.normalizeLanguage(optionValue) {
+                if RCTVideoAssetsUtils.isSameLanguage(value,optionValue) {
                     mediaOption = currentOption
                     break
                 }

--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -34,6 +34,15 @@ enum RCTVideoAssetsUtils {
             #endif
         }
     }
+    
+    static func normalizeLanguage(_ code: String?) -> String? {
+        guard let code = code else { return nil }
+        let lower = code.lowercased()
+        if let lang = Locale(identifier: lower).languageCode {
+            return lang
+        }
+        return lower
+    }
 }
 
 // MARK: - RCTVideoUtils

--- a/ios/Video/Features/RCTVideoUtils.swift
+++ b/ios/Video/Features/RCTVideoUtils.swift
@@ -35,13 +35,23 @@ enum RCTVideoAssetsUtils {
         }
     }
     
-    static func normalizeLanguage(_ code: String?) -> String? {
+    static func getLocale(_ code: String?) -> Locale? {
         guard let code = code else { return nil }
         let lower = code.lowercased()
-        if let lang = Locale(identifier: lower).languageCode {
-            return lang
+        
+        return Locale(identifier: lower)
+    }
+    
+    static func isSameLanguage(_ lhs: Locale?, _ rhs: Locale?) -> Bool {
+        guard let lhs = lhs, let rhs = rhs else {
+            return false
         }
-        return lower
+        
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            return lhs.language.languageCode == rhs.language.languageCode
+        } else {
+            return lhs.languageCode == rhs.languageCode
+        }
     }
 }
 


### PR DESCRIPTION
Normalizes the language code used for media option selection. This ensures that the correct media option is selected even if the language codes have different casing or regional variations.

The language code is normalized by:
- Converting the language code to lowercase.
- Extracting the primary language code from the locale identifier.

This change fixes an issue where the correct media option was not being selected due to inconsistencies in language codes.
This was because the extendedLanguageTag property of AVMediaSelectionOption complies with the RFC 4646 specification, so it can match different formats:

- **ISO 639** → en, it, fra
- **ISO 15924** → zh-Hans (simplified Chinese), zh-Hant (traditional Chinese)
- **ISO 3166** → en-US, en-GB, fr-CA
