### PR TITLE
Retries IMA ad request if video view not in hierarchy

### DIFF
--- a/ios/Video/Features/RCTIMAAdsManager.swift
+++ b/ios/Video/Features/RCTIMAAdsManager.swift
@@ -11,6 +11,11 @@
         /* Main point of interaction with the SDK. Created by the SDK as the result of an ad request. */
         private var adsManager: IMAAdsManager!
 
+        /* Retry state for requestAds when view is not yet in hierarchy */
+        private var _requestAdsRetryCount: Int = 0
+        private let _requestAdsMaxRetries: Int = 10
+        private let _requestAdsRetryDelayMs: Double = 100
+
         init(video: RCTVideo!, isPictureInPictureActive: @escaping () -> Bool) {
             _video = video
             _isPictureInPictureActive = isPictureInPictureActive
@@ -29,6 +34,32 @@
         }
 
         func requestAds() {
+            guard let _video else { return }
+
+            // IMA requires the ad container to be attached to the view hierarchy before requesting ads.
+            // If the view is not yet in the window, retry up to _requestAdsMaxRetries times.
+            guard _video.window != nil else {
+                if _requestAdsRetryCount < _requestAdsMaxRetries {
+                    _requestAdsRetryCount += 1
+                    DispatchQueue.main.asyncAfter(deadline: .now() + _requestAdsRetryDelayMs / 1000.0) { [weak self] in
+                        self?.requestAds()
+                    }
+                } else {
+                    _requestAdsRetryCount = 0
+                    // Max retries reached: attempt the request anyway — worst case only midrolls will play
+                    DispatchQueue.main.async { [weak self] in
+                        self?.performRequestAds()
+                    }
+                }
+                return
+            }
+
+            // Reset retry counter on success
+            _requestAdsRetryCount = 0
+            performRequestAds()
+        }
+
+        private func performRequestAds() {
             guard let _video else { return }
             // fixes RCTVideo --> RCTIMAAdsManager --> IMAAdsLoader --> IMAAdDisplayContainer --> RCTVideo memory leak.
             let adContainerView = UIView(frame: _video.bounds)


### PR DESCRIPTION
This pull request fixes the "Ads cannot be requested because the ad container is not attached to the view hierarchy" error that caused prerolls to not play.

Ensures that IMA ad requests are only performed when the video view is properly attached to the window hierarchy. The IMA SDK requires the ad container to be part of the view hierarchy for optimal ad loading.

- Implements a retry mechanism for ad requests if the video view is not yet available.
- Retries the request up to 10 times with a 100ms delay between attempts.
- If maximum retries are reached, proceeds with the ad request to allow for potential mid-roll ads.
- Improves reliability of ad playback, particularly for pre-roll ads, by waiting for the necessary view conditions.